### PR TITLE
Restored debugger support, using the MIT-licensed netcoredbg.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # free-omnisharp-vscode
 
-C# extension for vscode-compatible editors **without** the debugger.
+C# extension for vscode-compatible editors.
 
 ## Why?
 The debugger included in the official C# extension is [proprietary](https://aka.ms/VSCode-DotNet-DbgLicense) and is licensed to only work with Microsoft versions of vscode.
+This extension replaces it with a [custom version](https://github.com/jamsilva/netcoredbg) of [Samsung's MIT-licensed alternative](https://github.com/Samsung/netcoredbg/blob/master/LICENSE).
 
 ## Installation:
-this extension is published at [open-vsx.org](https://open-vsx.org/extension/muhammad-sammy/csharp).
+This extension is published at [open-vsx.org](https://open-vsx.org/extension/muhammad-sammy/csharp).
 
 ### Build from source:
 Requirements:
@@ -19,6 +20,8 @@ git clone https://github.com/muhammadsammy/free-omnisharp-vscode.git
 cd free-omnisharp-vscode
 
 npm install
+
+npm run compile
 
 vsce package
 ```

--- a/RuntimeLicenses/license.txt
+++ b/RuntimeLicenses/license.txt
@@ -1,4 +1,5 @@
 ﻿Omnisharp
+https://github.com/OmniSharp/omnisharp-vscode/blob/master/LICENSE.txt
 
 MIT License
 
@@ -22,6 +23,34 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+-------------------------------------------------------------------------------
+
+netcoredbg
+https://github.com/Samsung/netcoredbg/blob/master/LICENSE
+
+MIT License
+
+Copyright (c) 2017 Samsung Electronics Co., LTD
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 -------------------------------------------------------------------------------
 
 Razor Language Server

--- a/debugger-launchjson.md
+++ b/debugger-launchjson.md
@@ -166,13 +166,13 @@ The debugger steps over properties and operators in managed code by default. In 
 You can optionally enable or disable messages that should be logged to the output window. The flags in the logging field are: 'exceptions', 'moduleLoad', 'programOutput', 'engineLogging', and 'browserStdOut'.
 
 ## PipeTransport
-If you need to have the debugger to connect to a remote computer using another executable to relay standard input and output bewteen VS Code and the .NET Core debugger backend (vsdbg), 
+If you need to have the debugger to connect to a remote computer using another executable to relay standard input and output bewteen VS Code and the .NET Core debugger backend (netcoredbg), 
 then add the pipeTransport field folloing this schema:
 
     "pipeTransport": {
         "pipeProgram": "ssh",
         "pipeArgs": [ "-T", "ExampleAccount@ExampleTargetComputer" ],
-        "debuggerPath": "~/vsdbg/vsdbg",
+        "debuggerPath": "/usr/bin/netcoredbg",
         "pipeCwd": "${workspaceFolder}",
         "quoteArgs": true
     }

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     },
     {
       "id": "OmniSharp",
-      "description": "OmniSharp for OSX",
+      "description": "OmniSharp for macOS",
       "url": "https://download.visualstudio.microsoft.com/download/pr/629d3d3b-feb3-4034-a8f7-3262b4bcdace/f57fe2aed239711c69cda6c82ee7a2bf/omnisharp-osx-1.37.2.zip",
       "fallbackUrl": "https://roslynomnisharp.blob.core.windows.net/releases/1.37.2/omnisharp-osx-1.37.2.zip",
       "installPath": ".omnisharp/1.37.2",
@@ -247,6 +247,51 @@
       "installTestPath": "./.omnisharp/1.37.2/run",
       "platformId": "linux-x64",
       "integrity": "41A1111915AA66224174B561FA70B1C88340AA5D9FEBC8B8583B19B68F8A4F00"
+    },
+    {
+      "id": "Debugger",
+      "description": ".NET Core Debugger (Windows / x64)",
+      "url": "https://github.com/jamsilva/netcoredbg/releases/download/latest/netcoredbg-win64-master.zip",
+      "installPath": ".debugger",
+      "platforms": [
+        "win32"
+      ],
+      "architectures": [
+        "x86_64"
+      ],
+      "installTestPath": ".debugger/netcoredbg/netcoredbg.exe"
+    },
+    {
+      "id": "Debugger",
+      "description": ".NET Core Debugger (macOS / x64)",
+      "url": "https://github.com/jamsilva/netcoredbg/releases/download/latest/netcoredbg-osx-master.zip",
+      "installPath": ".debugger",
+      "platforms": [
+        "darwin"
+      ],
+      "architectures": [
+        "x86_64"
+      ],
+      "binaries": [
+        "netcoredbg/netcoredbg"
+      ],
+      "installTestPath": ".debugger/netcoredbg/netcoredbg"
+    },
+    {
+      "id": "Debugger",
+      "description": ".NET Core Debugger (linux / x64)",
+      "url": "https://github.com/jamsilva/netcoredbg/releases/download/latest/netcoredbg-linux-master.zip",
+      "installPath": ".debugger",
+      "platforms": [
+        "linux"
+      ],
+      "architectures": [
+        "x86_64"
+      ],
+      "binaries": [
+        "netcoredbg/netcoredbg"
+      ],
+      "installTestPath": ".debugger/netcoredbg/netcoredbg"
     },
     {
       "id": "Razor",
@@ -1174,7 +1219,7 @@
                 }
               },
               "pipeTransport": {
-                "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (vsdbg).",
+                "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (netcoredbg).",
                 "type": "object",
                 "required": [
                   "debuggerPath"
@@ -1183,7 +1228,7 @@
                   "pipeCwd": "${workspaceFolder}",
                   "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
                   "pipeArgs": [],
-                  "debuggerPath": "enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg"
+                  "debuggerPath": "enter the path for the debugger on the target machine, for example /usr/bin/netcoredbg"
                 },
                 "properties": {
                   "pipeCwd": {
@@ -1217,7 +1262,7 @@
                   "debuggerPath": {
                     "type": "string",
                     "description": "The full path to the debugger on the target machine.",
-                    "default": "enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg"
+                    "default": "enter the path for the debugger on the target machine, for example /usr/bin/netcoredbg"
                   },
                   "pipeEnv": {
                     "type": "object",
@@ -1606,7 +1651,7 @@
                 }
               },
               "pipeTransport": {
-                "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (vsdbg).",
+                "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (netcoredbg).",
                 "type": "object",
                 "required": [
                   "debuggerPath"
@@ -1615,7 +1660,7 @@
                   "pipeCwd": "${workspaceFolder}",
                   "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
                   "pipeArgs": [],
-                  "debuggerPath": "enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg"
+                  "debuggerPath": "enter the path for the debugger on the target machine, for example /usr/bin/netcoredbg"
                 },
                 "properties": {
                   "pipeCwd": {
@@ -1649,7 +1694,7 @@
                   "debuggerPath": {
                     "type": "string",
                     "description": "The full path to the debugger on the target machine.",
-                    "default": "enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg"
+                    "default": "enter the path for the debugger on the target machine, for example /usr/bin/netcoredbg"
                   },
                   "pipeEnv": {
                     "type": "object",
@@ -2004,7 +2049,7 @@
                 "pipeCwd": "^\"\\${workspaceFolder}\"",
                 "pipeProgram": "^\"${3:enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'}\"",
                 "pipeArgs": [],
-                "debuggerPath": "^\"${4:enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg}\""
+                "debuggerPath": "^\"${4:enter the path for the debugger on the target machine, for example /usr/bin/netcoredbg}\""
               }
             }
           },
@@ -2020,7 +2065,7 @@
                 "pipeCwd": "^\"\\${workspaceFolder}\"",
                 "pipeProgram": "^\"${1:enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'}\"",
                 "pipeArgs": [],
-                "debuggerPath": "^\"${2:enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg}\""
+                "debuggerPath": "^\"${2:enter the path for the debugger on the target machine, for example /usr/bin/netcoredbg}\""
               }
             }
           }
@@ -2271,7 +2316,7 @@
                 }
               },
               "pipeTransport": {
-                "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (vsdbg).",
+                "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (netcoredbg).",
                 "type": "object",
                 "required": [
                   "debuggerPath"
@@ -2280,7 +2325,7 @@
                   "pipeCwd": "${workspaceFolder}",
                   "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
                   "pipeArgs": [],
-                  "debuggerPath": "enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg"
+                  "debuggerPath": "enter the path for the debugger on the target machine, for example /usr/bin/netcoredbg"
                 },
                 "properties": {
                   "pipeCwd": {
@@ -2314,7 +2359,7 @@
                   "debuggerPath": {
                     "type": "string",
                     "description": "The full path to the debugger on the target machine.",
-                    "default": "enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg"
+                    "default": "enter the path for the debugger on the target machine, for example /usr/bin/netcoredbg"
                   },
                   "pipeEnv": {
                     "type": "object",
@@ -2703,7 +2748,7 @@
                 }
               },
               "pipeTransport": {
-                "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (vsdbg).",
+                "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (netcoredbg).",
                 "type": "object",
                 "required": [
                   "debuggerPath"
@@ -2712,7 +2757,7 @@
                   "pipeCwd": "${workspaceFolder}",
                   "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
                   "pipeArgs": [],
-                  "debuggerPath": "enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg"
+                  "debuggerPath": "enter the path for the debugger on the target machine, for example /usr/bin/netcoredbg"
                 },
                 "properties": {
                   "pipeCwd": {
@@ -2746,7 +2791,7 @@
                   "debuggerPath": {
                     "type": "string",
                     "description": "The full path to the debugger on the target machine.",
-                    "default": "enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg"
+                    "default": "enter the path for the debugger on the target machine, for example /usr/bin/netcoredbg"
                   },
                   "pipeEnv": {
                     "type": "object",

--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -16,7 +16,23 @@ import { DotnetInfo } from '../utils/getDotnetInfo';
 
 let _debugUtil: CoreClrDebugUtil = null;
 
-export async function activate(thisExtension: vscode.Extension<CSharpExtensionExports>, context: vscode.ExtensionContext, platformInformation: PlatformInformation, eventStream: EventStream) { }
+export async function activate(thisExtension: vscode.Extension<CSharpExtensionExports>, context: vscode.ExtensionContext, platformInformation: PlatformInformation, eventStream: EventStream) {
+    _debugUtil = new CoreClrDebugUtil(context.extensionPath);
+
+    if (!CoreClrDebugUtil.existsSync(_debugUtil.debugAdapterDir())) {
+        let isInvalidArchitecture: boolean = await checkForInvalidArchitecture(platformInformation, eventStream);
+        if (!isInvalidArchitecture) {
+            eventStream.post(new DebuggerPrerequisiteFailure("[ERROR]: C# Extension failed to install the debugger package."));
+            showInstallErrorMessage(eventStream);
+        }
+    } else if (!CoreClrDebugUtil.existsSync(_debugUtil.installCompleteFilePath())) {
+        completeDebuggerInstall(platformInformation, eventStream);
+    }
+
+    const factory = new DebugAdapterExecutableFactory(platformInformation, eventStream, thisExtension.packageJSON, thisExtension.extensionPath);
+    context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('coreclr', factory));
+    context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('clr', factory));
+}
 
 async function checkForInvalidArchitecture(platformInformation: PlatformInformation, eventStream: EventStream): Promise<boolean> {
     if (platformInformation) {
@@ -62,6 +78,11 @@ async function completeDebuggerInstall(platformInformation: PlatformInformation,
             // TODO: log telemetry?
             return false;
         });
+}
+
+function showInstallErrorMessage(eventStream: EventStream) {
+    eventStream.post(new DebuggerNotInstalledFailure());
+    vscode.window.showErrorMessage("An error occurred during installation of the .NET Core Debugger. The C# extension may need to be reinstalled.");
 }
 
 function showDotnetToolsWarning(message: string): void {
@@ -133,7 +154,7 @@ export class DebugAdapterExecutableFactory implements vscode.DebugAdapterDescrip
 
         // use the executable specified in the package.json if it exists or determine it based on some other information (e.g. the session)
         if (!executable) {
-            const command = path.join(common.getExtensionPath(), ".debugger", "vsdbg-ui" + CoreClrDebugUtil.getPlatformExeExtension());
+            const command = path.join(common.getExtensionPath(), ".debugger", "netcoredbg", "netcoredbg" + CoreClrDebugUtil.getPlatformExeExtension());
             executable = new vscode.DebugAdapterExecutable(command);
         }
 

--- a/src/coreclr-debug/debuggerEventsProtocol.ts
+++ b/src/coreclr-debug/debuggerEventsProtocol.ts
@@ -3,15 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// This contains the definition of messages that VsDbg-UI can send back to a listener which registers itself via the 'debuggerEventsPipeName'
+// This contains the definition of messages that netcoredbg can send back to a listener which registers itself via the 'debuggerEventsPipeName'
 // property on a launch or attach request.
 //
 // All messages are sent as UTF-8 JSON text with a tailing '\n'
 export namespace DebuggerEventsProtocol {
     export module EventType {
-        // Indicates that the vsdbg-ui has received the attach or launch request and is starting up
+        // Indicates that the netcoredbg has received the attach or launch request and is starting up
         export const Starting = "starting";
-        // Indicates that vsdbg-ui has successfully launched the specified process.
+        // Indicates that netcoredbg has successfully launched the specified process.
         // The ProcessLaunchedEvent interface details the event payload.
         export const ProcessLaunched = "processLaunched";
         // Debug session is ending

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -59,12 +59,12 @@
     "PipeTransport": {
       "type": "object",
       "required": [ "debuggerPath" ],
-      "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (vsdbg).",
+      "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (netcoredbg).",
       "default": {
         "pipeCwd": "${workspaceFolder}",
         "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
         "pipeArgs": [],
-        "debuggerPath": "enter the path for the debugger on the target machine, for example ~/vsdbg/vsdbg"
+        "debuggerPath": "enter the path for the debugger on the target machine, for example /usr/bin/netcoredbg"
       },
       "properties": {
         "pipeCwd": {
@@ -97,7 +97,7 @@
         "debuggerPath": {
           "type": "string",
           "description": "The full path to the debugger on the target machine.",
-          "default": "~/vsdbg/vsdbg"
+          "default": "/usr/bin/netcoredbg"
         },
         "pipeEnv": {
           "type": "object",
@@ -354,7 +354,7 @@
         },
         "pipeTransport": {
           "$ref": "#/definitions/PipeTransport",
-          "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (vsdbg)."
+          "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (netcoredbg)."
         },
         "suppressJITOptimizations": {
           "type": "boolean",
@@ -443,7 +443,7 @@
         },
         "pipeTransport": {
           "$ref": "#/definitions/PipeTransport",
-          "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (vsdbg)."
+          "description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (netcoredbg)."
         },
         "suppressJITOptimizations": {
           "type": "boolean",

--- a/test/unitTests/testAssets/testAssets.ts
+++ b/test/unitTests/testAssets/testAssets.ts
@@ -106,8 +106,7 @@ export let testPackageJSON = {
         },
         {
             "description": "Non omnisharp package without platformId",
-            "url": "https://download.visualstudio.microsoft.com/download/pr/100317420/a30d7e11bc435433d297adc824ee837f/coreclr-debug-win7-x64.zip",
-            "fallbackUrl": "https://vsdebugger.blob.core.windows.net/coreclr-debug-1-14-4/coreclr-debug-win7-x64.zip",
+            "url": "https://github.com/jamsilva/netcoredbg/releases/download/latest/netcoredbg-win64-master.zip",
             "installPath": ".debugger",
             "platforms": [
                 "win32"
@@ -115,7 +114,7 @@ export let testPackageJSON = {
             "architectures": [
                 "x86_64"
             ],
-            "installTestPath": "./.debugger/vsdbg-ui.exe"
+            "installTestPath": "./.debugger/netcoredbg/netcoredbg.exe"
         }
     ]
 };


### PR DESCRIPTION
This pull request restores debugging functionality, solving #2.
I built the extension on my Linux computer and installed it in Code - OSS. The debugger works without any need for changes to the launch.json file.
The binaries are downloaded from my [custom netcoredbg repo](https://github.com/jamsilva/netcoredbg/releases/tag/latest) instead of vsdbg.
Because I only tested this locally, on a single Linux computer, you may want to do some tests yourself before merging this.