### PR TITLE
Use Samsung-provided releases of netcoredbg

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ C# extension for vscode-compatible editors.
 
 ## Why?
 The debugger included in the official C# extension is [proprietary](https://aka.ms/VSCode-DotNet-DbgLicense) and is licensed to only work with Microsoft versions of vscode.
-This extension replaces it with a [custom version](https://github.com/jamsilva/netcoredbg) of [Samsung's MIT-licensed alternative](https://github.com/Samsung/netcoredbg/blob/master/LICENSE).
+This extension replaces it with [Samsung's MIT-licensed alternative](https://github.com/Samsung/netcoredbg/blob/master/LICENSE).
 
 ## Installation:
 This extension is published at [open-vsx.org](https://open-vsx.org/extension/muhammad-sammy/csharp).

--- a/package-lock.json
+++ b/package-lock.json
@@ -484,6 +484,15 @@
             "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
             "dev": true
         },
+        "@types/minipass": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@types/minipass/-/minipass-2.2.0.tgz",
+            "integrity": "sha512-wuzZksN4w4kyfoOv/dlpov4NOunwutLA/q7uc00xU02ZyUY+aoM5PWIXEKBMnm0NHd4a+N71BMjq+x7+2Af1fg==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/mkdirp": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
@@ -518,6 +527,16 @@
             "dev": true,
             "requires": {
                 "@types/glob": "*",
+                "@types/node": "*"
+            }
+        },
+        "@types/tar": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@types/tar/-/tar-4.0.3.tgz",
+            "integrity": "sha512-Z7AVMMlkI8NTWF0qGhC4QIX0zkV/+y0J8x7b/RsHrN0310+YNjoJd8UrApCiGBCWtKjxS9QhNqLi2UJNToh5hA==",
+            "dev": true,
+            "requires": {
+                "@types/minipass": "*",
                 "@types/node": "*"
             }
         },
@@ -3818,6 +3837,14 @@
                 "universalify": "^0.1.0"
             }
         },
+        "fs-minipass": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+            "requires": {
+                "minipass": "^3.0.0"
+            }
+        },
         "fs-mkdirp-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
@@ -6261,6 +6288,37 @@
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
             "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
             "dev": true
+        },
+        "minipass": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+            "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+            "requires": {
+                "yallist": "^4.0.0"
+            },
+            "dependencies": {
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+                }
+            }
+        },
+        "minizlib": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+            "requires": {
+                "minipass": "^3.0.0",
+                "yallist": "^4.0.0"
+            },
+            "dependencies": {
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+                }
+            }
         },
         "mississippi": {
             "version": "3.0.0",
@@ -9055,6 +9113,31 @@
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
             "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
             "dev": true
+        },
+        "tar": {
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
+            "integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
+            "requires": {
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.0.0",
+                "minipass": "^3.0.0",
+                "minizlib": "^2.1.1",
+                "mkdirp": "^1.0.3",
+                "yallist": "^4.0.0"
+            },
+            "dependencies": {
+                "chownr": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+                    "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+                }
+            }
         },
         "tar-stream": {
             "version": "1.6.2",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "semver": "5.6.0",
     "stream": "0.0.2",
     "strip-bom": "3.0.0",
+    "tar": "6.0.5",
     "tmp": "0.0.33",
     "vscode-debugprotocol": "1.33.0",
     "vscode-extension-telemetry": "0.1.6",
@@ -111,6 +112,7 @@
     "@types/mocha": "5.2.5",
     "@types/node": "10.12.24",
     "@types/semver": "5.5.0",
+    "@types/tar": "4.0.3",
     "@types/tmp": "0.0.33",
     "@types/unzipper": "^0.9.1",
     "@types/vscode": "1.33.0",
@@ -251,7 +253,8 @@
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (Windows / x64)",
-      "url": "https://github.com/jamsilva/netcoredbg/releases/download/latest/netcoredbg-win64-master.zip",
+      "url": "https://github.com/Samsung/netcoredbg/releases/latest/download/netcoredbg-win64-master.zip",
+      "fallbackUrl": "https://web.archive.org/web/20201023212102if_/https://github-production-release-asset-2e65be.s3.amazonaws.com/113926796/d4b97d80-155d-11eb-8d5f-3dd1c01c1a8e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20201023%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20201023T212101Z&X-Amz-Expires=300&X-Amz-Signature=eee689635c857b27244d450d90d65600f392ed41b7d5a6ce77fa44fe2060f879&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=113926796&response-content-disposition=attachment%3B%20filename%3Dnetcoredbg-win64.zip&response-content-type=application%2Foctet-stream",
       "installPath": ".debugger",
       "platforms": [
         "win32"
@@ -264,7 +267,8 @@
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (macOS / x64)",
-      "url": "https://github.com/jamsilva/netcoredbg/releases/download/latest/netcoredbg-osx-master.zip",
+      "url": "https://github.com/Samsung/netcoredbg/releases/latest/download/netcoredbg-win64-master.zip",
+      "fallbackUrl": "https://web.archive.org/web/20201023212454if_/https://github-production-release-asset-2e65be.s3.amazonaws.com/113926796/e77a8500-1552-11eb-8b31-fe0e14726f36?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20201023%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20201023T212454Z&X-Amz-Expires=300&X-Amz-Signature=2a34e55e502e63d3e2b470ec64124f2a5ec4e31dfc71b4e4058171a747f940e6&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=113926796&response-content-disposition=attachment%3B%20filename%3Dnetcoredbg-osx.tar.gz&response-content-type=application%2Foctet-stream",
       "installPath": ".debugger",
       "platforms": [
         "darwin"
@@ -272,24 +276,19 @@
       "architectures": [
         "x86_64"
       ],
-      "binaries": [
-        "netcoredbg/netcoredbg"
-      ],
       "installTestPath": ".debugger/netcoredbg/netcoredbg"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux / x64)",
-      "url": "https://github.com/jamsilva/netcoredbg/releases/download/latest/netcoredbg-linux-master.zip",
+      "url": "https://github.com/Samsung/netcoredbg/releases/latest/download/netcoredbg-linux-bionic.tar.gz",
+      "fallbackUrl": "https://web.archive.org/web/20201023212424if_/https://github-production-release-asset-2e65be.s3.amazonaws.com/113926796/cddb3c80-1556-11eb-832f-5361171540d7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20201023%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20201023T212424Z&X-Amz-Expires=300&X-Amz-Signature=67fb4e138819eaa325ccde7ed6965d9db54fc2296b0a9d2fe4518325d4ab04f2&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=113926796&response-content-disposition=attachment%3B%20filename%3Dnetcoredbg-linux-bionic.tar.gz&response-content-type=application%2Foctet-stream",
       "installPath": ".debugger",
       "platforms": [
         "linux"
       ],
       "architectures": [
         "x86_64"
-      ],
-      "binaries": [
-        "netcoredbg/netcoredbg"
       ],
       "installTestPath": ".debugger/netcoredbg/netcoredbg"
     },

--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -155,7 +155,7 @@ export class DebugAdapterExecutableFactory implements vscode.DebugAdapterDescrip
         // use the executable specified in the package.json if it exists or determine it based on some other information (e.g. the session)
         if (!executable) {
             const command = path.join(common.getExtensionPath(), ".debugger", "netcoredbg", "netcoredbg" + CoreClrDebugUtil.getPlatformExeExtension());
-            executable = new vscode.DebugAdapterExecutable(command);
+            executable = new vscode.DebugAdapterExecutable(command, ["--interpreter=vscode"]);
         }
 
         // make VS Code launch the DA executable

--- a/src/packageManager/TarGzInstaller.ts
+++ b/src/packageManager/TarGzInstaller.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as tar from 'tar';
+import { Readable } from 'stream';
+import { EventStream } from "../EventStream";
+import { InstallationStart, ZipError } from "../omnisharp/loggingEvents";
+import { NestedError } from '../NestedError';
+import { AbsolutePath } from './AbsolutePath';
+
+export async function InstallTarGz(buffer: Buffer, description: string, destinationInstallPath: AbsolutePath, eventStream: EventStream): Promise<void> {
+    eventStream.post(new InstallationStart(description));
+
+    return new Promise<void>((resolve, reject) => {
+        const reader = new Readable();
+        reader.push(buffer);
+        reader.push(null);
+        reader.pipe(
+            tar.extract({
+                cwd: destinationInstallPath.value
+            })
+        )
+        .on('error', err => {
+            let message = "C# Extension was unable to install its dependencies. Please check your internet connection. If you use a proxy server, please visit https://aka.ms/VsCodeCsharpNetworking";
+            eventStream.post(new ZipError(message));
+            return reject(new NestedError(message));
+        })
+        .on('end', () => resolve());
+    });
+}
+

--- a/src/packageManager/downloadAndInstallPackages.ts
+++ b/src/packageManager/downloadAndInstallPackages.ts
@@ -6,6 +6,7 @@
 import { PackageError } from './PackageError';
 import { NestedError } from "../NestedError";
 import { DownloadFile } from './FileDownloader';
+import { InstallTarGz } from './TarGzInstaller';
 import { InstallZip } from './ZipInstaller';
 import { EventStream } from '../EventStream';
 import { NetworkSettingsProvider } from "../NetworkSettings";
@@ -32,7 +33,13 @@ export async function downloadAndInstallPackages(packages: AbsolutePathPackage[]
                     let buffer = await DownloadFile(pkg.description, eventStream, provider, pkg.url, pkg.fallbackUrl);
                     if (downloadValidator(buffer, pkg.integrity, eventStream)) {
                         installationStage = "installPackage";
-                        await InstallZip(buffer, pkg.description, pkg.installPath, pkg.binaries, eventStream);
+                        if (pkg.url.includes(".tar.gz")) {
+                            await InstallTarGz(buffer, pkg.description, pkg.installPath, eventStream);
+                        }
+                        else {
+                            await InstallZip(buffer, pkg.description, pkg.installPath, pkg.binaries, eventStream);
+                        }
+
                         installationStage = 'touchLockFile';
                         await touchInstallFile(pkg.installPath, InstallFileType.Lock);
                         break;


### PR DESCRIPTION
When adding support for netcoredbg in #4 there were two problems that had to be worked around:
1. Samsung's builds were broken (see https://github.com/Samsung/netcoredbg/issues/45).
2. The Linux and macOS builds were packaged to tar.gz but the extension only had support for zip.

From what I can tell, the first problem seems to be fixed now (even if the issue is still open).
For the second, I added support for tar.gz. Because I have not worked with Typescript before, the quality of code may be _bad_ but at least it works for me.