### PR TITLE
Fix NetCoreDbg download links

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,8 +253,8 @@
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (Windows / x64)",
-      "url": "https://github.com/Samsung/netcoredbg/releases/latest/download/netcoredbg-win64-master.zip",
-      "fallbackUrl": "https://web.archive.org/web/20201023212102if_/https://github-production-release-asset-2e65be.s3.amazonaws.com/113926796/d4b97d80-155d-11eb-8d5f-3dd1c01c1a8e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20201023%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20201023T212101Z&X-Amz-Expires=300&X-Amz-Signature=eee689635c857b27244d450d90d65600f392ed41b7d5a6ce77fa44fe2060f879&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=113926796&response-content-disposition=attachment%3B%20filename%3Dnetcoredbg-win64.zip&response-content-type=application%2Foctet-stream",
+      "url": "https://github.com/Samsung/netcoredbg/releases/latest/download/netcoredbg-win64.zip",
+      "fallbackUrl": "https://web.archive.org/web/20201114153556if_/https://github-production-release-asset-2e65be.s3.amazonaws.com/113926796/d4b97d80-155d-11eb-8d5f-3dd1c01c1a8e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20201114%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20201114T153556Z&X-Amz-Expires=300&X-Amz-Signature=cca2fa29711b17bf0ab332e8142fc4c27792f515d53dc685396d8ea1009f4bd8&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=113926796&response-content-disposition=attachment%3B%20filename%3Dnetcoredbg-win64.zip&response-content-type=application%2Foctet-stream",
       "installPath": ".debugger",
       "platforms": [
         "win32"
@@ -267,8 +267,8 @@
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (macOS / x64)",
-      "url": "https://github.com/Samsung/netcoredbg/releases/latest/download/netcoredbg-win64-master.zip",
-      "fallbackUrl": "https://web.archive.org/web/20201023212454if_/https://github-production-release-asset-2e65be.s3.amazonaws.com/113926796/e77a8500-1552-11eb-8b31-fe0e14726f36?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20201023%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20201023T212454Z&X-Amz-Expires=300&X-Amz-Signature=2a34e55e502e63d3e2b470ec64124f2a5ec4e31dfc71b4e4058171a747f940e6&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=113926796&response-content-disposition=attachment%3B%20filename%3Dnetcoredbg-osx.tar.gz&response-content-type=application%2Foctet-stream",
+      "url": "https://github.com/Samsung/netcoredbg/releases/latest/download/netcoredbg-osx.tar.gz",
+      "fallbackUrl": "https://web.archive.org/web/20201114153845if_/https://github-production-release-asset-2e65be.s3.amazonaws.com/113926796/e77a8500-1552-11eb-8b31-fe0e14726f36?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20201114%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20201114T153659Z&X-Amz-Expires=300&X-Amz-Signature=5782fc0120f26ad4ec919f9cc21b70c42986436a05de7f857fff3e7604e077fb&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=113926796&response-content-disposition=attachment%3B%20filename%3Dnetcoredbg-osx.tar.gz&response-content-type=application%2Foctet-stream",
       "installPath": ".debugger",
       "platforms": [
         "darwin"


### PR DESCRIPTION
Just installed this extension in VSCodium on Mac, and it was telling me it couldn't download the .NET Core Debugger. I think this should do the trick!

Turns out the Mac version in `package.json` was pointing to the download for the Windows release, and actually the Windows download URL is outdated, too: the Windows release is now named `netcoredbg-win64.zip` instead of `netcoredbg-win64-master.zip`.

I also updated the archive URLs for both versions while I was at it.

-----

I unfortunately wasn't able to test this PR myself, because `npm install`, `vsce package`, and `npm run test` all fail for me. I wonder if it has to do with the fact that I haven't downloaded the .NET Core Debugger, but I'm not sure.

```console
$ npm install
⸨  ░░░░░░░░░░░░░░░░⸩ ⠧ loadDep:yauzl: sill install loadAllDepsIntoIde
> fsevents@1.2.13 install /Users/tymick/dev/muhammadsammy/free-omnisharp-vscode/node_modules/glob-watcher/node_modules/fsevents
> node install.js

  SOLINK_MODULE(target) Release/.node
  CXX(target) Release/obj.target/fse/fsevents.o
  SOLINK_MODULE(target) Release/fse.node

> fsevents@1.2.13 install /Users/tymick/dev/muhammadsammy/free-omnisharp-vscode/node_modules/watchpack-chokidar2/node_modules/fsevents
> node install.js

  SOLINK_MODULE(target) Release/.node
  CXX(target) Release/obj.target/fse/fsevents.o
  SOLINK_MODULE(target) Release/fse.node

> core-js@2.6.11 postinstall /Users/tymick/dev/muhammadsammy/free-omnisharp-vscode/node_modules/core-js
> node -e "try{require('./postinstall')}catch(e){}"

Thank you for using core-js ( https://github.com/zloirock/core-js ) for polyfilling JavaScript standard library!

The project needs your help! Please consider supporting of core-js on Open Collective or Patreon: 
> https://opencollective.com/core-js 
> https://www.patreon.com/zloirock 

Also, the author of core-js ( https://github.com/zloirock ) is looking for a good job -)


> csharp@1.23.5 postinstall /Users/tymick/dev/muhammadsammy/free-omnisharp-vscode
> node ./node_modules/vscode/bin/install


$ vsce package
Executing prepublish script 'npm run vscode:prepublish'...

> csharp@1.23.5 vscode:prepublish /Users/tymick/dev/muhammadsammy/free-omnisharp-vscode
> tsc -p ./ && webpack --mode production


 ERROR  npm failed with exit code 1
$ npm run test

> csharp@1.23.5 test /Users/tymick/dev/muhammadsammy/free-omnisharp-vscode
> gulp test


$
```