### PR TITLE
Add download-dependencies script

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "packageDev": "npm run compileDev && node esbuild.js",
     "l10nDevGenerateLocalizationBundle": "npx @vscode/l10n-dev export --outDir ./l10n ./src",
     "compile:razorTextMate": "npx js-yaml src/razor/syntaxes/aspnetcorerazor.tmLanguage.yml > src/razor/syntaxes/aspnetcorerazor.tmLanguage.json",
+    "download-dependencies": "ts-node scripts/downloadDependencies.ts",
     "test:unit": "npm run compileDev && gulp test:unit",
     "test:integration:csharp": "npm run packageDev && gulp test:integration:csharp",
     "test:integration:razor:cohost": "npm run packageDev && gulp test:integration:razor:cohost",

--- a/scripts/downloadDependencies.ts
+++ b/scripts/downloadDependencies.ts
@@ -1,0 +1,151 @@
+/**
+ * Standalone script to download all runtime dependencies declared in package.json.
+ * Wraps the same modules the extension uses at runtime so that unpacking logic is identical.
+ *
+ * Usage:
+ *   npm run download-dependencies
+ *
+ * The dependencies are installed under the `dist/` directory at the repository root so that
+ * the resulting VSIX can be used in air-gapped environments without any further network access.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { EventStream } from '../src/eventStream';
+import { downloadAndInstallPackages } from '../src/packageManager/downloadAndInstallPackages';
+import { getRuntimeDependenciesPackages } from '../src/tools/runtimeDependencyPackageUtils';
+import { AbsolutePathPackage } from '../src/packageManager/absolutePathPackage';
+import { filterPlatformPackages } from '../src/packageManager/packageFilterer';
+import { isValidDownload } from '../src/packageManager/isValidDownload';
+import { PlatformInformation } from '../src/shared/platform';
+import NetworkSettings from '../src/networkSettings';
+import type { NetworkSettingsProvider } from '../src/networkSettings';
+import {
+    BaseEvent,
+    DownloadStart,
+    DownloadSuccess,
+    DownloadFailure,
+    DownloadProgress,
+    DownloadSizeObtained,
+    InstallationFailure,
+    IntegrityCheckFailure,
+    DownloadFallBack,
+} from '../src/shared/loggingEvents';
+import { EventType } from '../src/shared/eventType';
+
+const packageJSON = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8')
+) as Record<string, unknown>;
+
+/** Output directory – all packages are installed relative to this path. */
+const distPath = path.resolve(__dirname, '..', 'dist');
+
+/**
+ * Target platform for dependency filtering.
+ * To override, replace `PlatformInformation.GetCurrent()` with a custom instance, e.g.:
+ * ```ts
+ * new PlatformInformation('linux', 'x86_64')
+ * ```
+ */
+const platformInfo = PlatformInformation.GetCurrent();
+
+/** Maps EventStream events to human-readable console output. */
+function logEvent(event: BaseEvent): void {
+    switch (event.type) {
+        case EventType.PackageInstallStart:
+            console.log('\nStarting dependency downloads...');
+            break;
+
+        case EventType.DownloadStart:
+            process.stdout.write(`\nDownloading ${(event as DownloadStart).packageDescription}...`);
+            break;
+
+        case EventType.DownloadSizeObtained: {
+            const mb = ((event as DownloadSizeObtained).packageSize / 1024 / 1024).toFixed(1);
+            process.stdout.write(` (${mb} MB)`);
+            break;
+        }
+
+        case EventType.DownloadProgress: {
+            const pct = Math.floor((event as DownloadProgress).downloadPercentage);
+            if (pct % 10 === 0) {
+                process.stdout.write(` ${pct}%`);
+            }
+            break;
+        }
+
+        case EventType.DownloadSuccess:
+            console.log(` ✓ ${(event as DownloadSuccess).message}`);
+            break;
+
+        case EventType.DownloadFailure:
+            console.error(` ✗ ${(event as DownloadFailure).message}`);
+            break;
+
+        case EventType.DownloadFallBack:
+            console.log(`\n  Trying fallback URL: ${(event as DownloadFallBack).fallbackUrl}`);
+            break;
+
+        case EventType.InstallationFailure: {
+            const e = event as InstallationFailure;
+            console.error(`\nInstallation failed at stage '${e.stage}': ${e.error}`);
+            break;
+        }
+
+        case EventType.IntegrityCheckFailure: {
+            const e = event as IntegrityCheckFailure;
+            console.warn(
+                `\n  Integrity check failed for ${e.packageDescription}${e.retry ? ' – retrying' : ''}`
+            );
+            break;
+        }
+
+        case EventType.InstallationSuccess:
+            console.log('  Installed successfully.');
+            break;
+    }
+}
+
+async function main(): Promise<void> {
+    const eventStream = new EventStream();
+    eventStream.subscribe(logEvent);
+
+    // Honour standard proxy environment variables; fall back to no proxy.
+    const proxy = process.env['HTTP_PROXY'] ?? process.env['http_proxy'] ?? '';
+    const networkSettingsProvider: NetworkSettingsProvider = () => new NetworkSettings(proxy, true);
+
+    // Retrieve every package declared in runtimeDependencies
+    const packages = getRuntimeDependenciesPackages(packageJSON);
+    const absolutePackages = packages.map((pkg) =>
+        AbsolutePathPackage.getAbsolutePathPackage(pkg, distPath)
+    );
+    const filteredPackages = filterPlatformPackages(absolutePackages, platformInfo);
+
+    console.log(
+        `Installing ${filteredPackages.length} of ${absolutePackages.length} runtime dependencies` +
+        ` for ${platformInfo.platform}/${platformInfo.architecture} to '${distPath}'...`
+    );
+
+    const results = await downloadAndInstallPackages(
+        filteredPackages,
+        networkSettingsProvider,
+        eventStream,
+        isValidDownload
+    );
+
+    const failed = Object.entries(results)
+        .filter(([, ok]) => !ok)
+        .map(([id]) => id);
+
+    if (failed.length > 0) {
+        console.error(`\nFailed to install: ${failed.join(', ')}`);
+        process.exit(1);
+    }
+
+    console.log('\nAll runtime dependencies downloaded successfully!');
+}
+
+main().catch((err: unknown) => {
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
# Rationale

Currently, the extension downloads some of its runtime dependencies on-the-fly after starting for the first time. This does not work for air-gapped or otherwise restricted environments without access to the internet. It's also suboptimal for remote development environments (like Coder, GitLab Workspaces, Posit Workbench, etc.) that run vscode from within a docker container. In these cases, pre-downloading the runtime dependencies into the docker container without running vscode is very useful. Potentially, one might want to publish a version with the dependencies built in on an internal registry, too.

# Solution

To satisfy these use cases, I wrote a script that imports the relevant functionality for downloading the runtime dependencies directly from the extension modules and executes them such that the dependencies are downloaded to `./dist`, where the extension would be built as well.

# Testing

I've already tested this script extensively in our own environments and on my macOS development machine with multiple versions of the extension (down to 2.90.60, which we have to run on some systems) and it seems to work perfectly, i.e. the extension no longer displays any logs about downloading its dependencies and all analysis features work as expected.

I have not tested this script on Windows.

I am also unsure how one would write an integration test for this, my overview over the codebase is currently not sufficient for that.

# Alternatives

Right now, there's one universal build of the extension. All platform-specific dependencies are downloaded on startup. It might also be possible to publish separate builds of the extension for every supported platform that already includes the dependencies. This would increase the size of the extension bundle by ~120MB AFAICT and would complicate the release process.

I opted for this simpler approach because my usecase is admittedly quite niche already, so it seems unreasonable to expect you to dedicate such a high amount of work to satisfying it. This small script seems almost trivial in maintenance cost.

# Disclosure of AI Assistance

The script was mostly written with GitHub Copilot using Claude Sonnet 4.6. I gave it a pretty clear prompt based on my own understanding of the codebase:

> The repository you're in is a vscode extension. I want to use it in an air-gapped environment, but many dependencies are not bundled with the extension. Instead, they are downloaded from the internet on demand once the extension starts for the first time. You can see an example for this in `razorOmnisharpDownloader.ts`.
>
> What I want you to do is to add a command download-dependencies to package.json that downloads and unpacks all the dependencies as the extension would do it at runtime. This means that this script is NOT allowed to reimplement the logic that's already present in the different modules of the extension as they might contain custom unpacking etc. The base folder for the output should be `dist`. I think the best course of action is to write a new module that wraps `getRuntimeDependenciesPackages`, `getAbsolutePathPackagesToInstall`, `filterPlatformPackages` and `downloadAndInstallPackages` in a new script that only filters the `runtimeDependencies` by platform and then installs them.

Afterwards, I reviewed the entire script and did some small modifications (like not hardcoding the platform).